### PR TITLE
feat(ci): add VST3 plugin to release builds + upstream sync

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,9 @@ jobs:
       - name: Install build tools
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y -qq cmake build-essential pkg-config libopenblas-dev
+          sudo apt-get install -y -qq cmake build-essential pkg-config libopenblas-dev \
+            libasound2-dev libfreetype6-dev libx11-dev libxrandr-dev libxcursor-dev \
+            libxinerama-dev libgl1-mesa-dev
 
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2
@@ -85,6 +87,17 @@ jobs:
           "$BIN/quantize"       2>&1 | head -3
           "$BIN/mp3-codec"      2>&1 | head -3
 
+      - name: Build VST3 plugin
+        run: |
+          cmake -S plugins/acestep_vst3 -B build/acestep_vst3 -DCMAKE_BUILD_TYPE=Release
+          cmake --build build/acestep_vst3 --config Release -j "$(nproc)"
+
+      - name: Verify VST3 bundle
+        run: |
+          VST3_DIR="build/acestep_vst3/acestep_vst3_artefacts/Release/VST3"
+          test -d "$VST3_DIR" || { echo "FATAL: VST3 bundle not found at $VST3_DIR"; exit 1; }
+          echo "VST3 bundle verified."
+
       - name: Resolve release tag
         id: tag
         shell: bash
@@ -103,6 +116,7 @@ jobs:
           cp models.sh dist/ 2>/dev/null || true
           cp -r examples dist/ 2>/dev/null || true
           cp -r tools/webui-vst3 dist/ 2>/dev/null || true
+          cp -r build/acestep_vst3/acestep_vst3_artefacts/Release/VST3/*.vst3 dist/ 2>/dev/null || true
           tar -C dist -czf "acestep-linux-x64.tar.gz" .
 
       - name: Upload to release
@@ -156,6 +170,17 @@ jobs:
           "$BIN/quantize"       2>&1 | head -3
           "$BIN/mp3-codec"      2>&1 | head -3
 
+      - name: Build VST3 plugin
+        run: |
+          cmake -S plugins/acestep_vst3 -B build/acestep_vst3 -DCMAKE_BUILD_TYPE=Release
+          cmake --build build/acestep_vst3 --config Release -j "$(sysctl -n hw.ncpu)"
+
+      - name: Verify VST3 bundle
+        run: |
+          VST3_DIR="build/acestep_vst3/acestep_vst3_artefacts/Release/VST3"
+          test -d "$VST3_DIR" || { echo "FATAL: VST3 bundle not found at $VST3_DIR"; exit 1; }
+          echo "VST3 bundle verified."
+
       - name: Resolve release tag
         id: tag
         shell: bash
@@ -179,6 +204,7 @@ jobs:
           cp models.sh dist/ 2>/dev/null || true
           cp -r examples dist/ 2>/dev/null || true
           cp -r tools/webui-vst3 dist/ 2>/dev/null || true
+          cp -r build/acestep_vst3/acestep_vst3_artefacts/Release/VST3/*.vst3 dist/ 2>/dev/null || true
           tar -C dist -czf "acestep-macos-arm64-metal.tar.gz" .
 
       - name: Upload to release
@@ -270,6 +296,22 @@ jobs:
           "$BIN/quantize.exe"       2>&1 | head -3
           "$BIN/mp3-codec.exe"      2>&1 | head -3
 
+      - name: Build VST3 plugin
+        shell: pwsh
+        run: |
+          cmake -S plugins/acestep_vst3 -B build-vst3 --log-level=ERROR
+          cmake --build build-vst3 --config Release -j $env:NUMBER_OF_PROCESSORS
+
+      - name: Verify VST3 bundle
+        shell: pwsh
+        run: |
+          $vst3Dir = "build-vst3\acestep_vst3_artefacts\Release\VST3"
+          if (-not (Test-Path $vst3Dir)) {
+            Write-Error "FATAL: VST3 bundle not found at $vst3Dir"
+            exit 1
+          }
+          Write-Host "VST3 bundle verified."
+
       - name: Resolve release tag
         id: tag
         shell: bash
@@ -289,6 +331,7 @@ jobs:
           Copy-Item "models.sh" dist\ -ErrorAction SilentlyContinue
           Copy-Item "examples" dist\ -Recurse -ErrorAction SilentlyContinue
           Copy-Item "tools\webui-vst3" dist\ -Recurse -ErrorAction SilentlyContinue
+          Copy-Item "build-vst3\acestep_vst3_artefacts\Release\VST3\*" dist\ -Recurse -ErrorAction SilentlyContinue
           Compress-Archive -Path dist\* -DestinationPath "acestep-windows-x64.zip"
 
       - name: Upload to release

--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -1,0 +1,96 @@
+name: Sync upstream acestep.cpp
+
+on:
+  schedule:
+    - cron: '0 9 * * 1'  # Weekly Monday 9am UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync:
+    name: Check & sync upstream
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Add upstream remote
+        run: |
+          git remote add upstream https://github.com/ServeurpersoCom/acestep.cpp.git || true
+          git fetch upstream master
+
+      - name: Check for new upstream commits
+        id: check
+        run: |
+          NEW_COMMITS=$(git log HEAD..upstream/master --oneline | wc -l | tr -d ' ')
+          echo "count=$NEW_COMMITS" >> $GITHUB_OUTPUT
+          if [ "$NEW_COMMITS" -eq 0 ]; then
+            echo "Already up to date with upstream."
+          else
+            echo "$NEW_COMMITS new upstream commit(s) found."
+            echo "summary<<EOF" >> $GITHUB_OUTPUT
+            git log HEAD..upstream/master --oneline --no-decorate | head -20 >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create sync branch and merge
+        if: steps.check.outputs.count != '0'
+        id: merge
+        run: |
+          BRANCH="upstream-sync-$(date +%Y%m%d)"
+          git checkout -b "$BRANCH"
+          echo "branch=$BRANCH" >> $GITHUB_OUTPUT
+
+          if git merge upstream/master --no-edit; then
+            echo "conflict=false" >> $GITHUB_OUTPUT
+          else
+            # Mark conflicts so reviewer can see them
+            git add -A
+            git commit --no-edit -m "chore: merge upstream (conflicts need manual resolution)" || true
+            echo "conflict=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Push branch
+        if: steps.check.outputs.count != '0'
+        run: |
+          git push origin "${{ steps.merge.outputs.branch }}"
+
+      - name: Create pull request
+        if: steps.check.outputs.count != '0'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          CONFLICT_NOTE=""
+          if [ "${{ steps.merge.outputs.conflict }}" = "true" ]; then
+            CONFLICT_NOTE=$'\n\n> **Warning:** Merge conflicts were detected and need manual resolution.'
+          fi
+
+          gh pr create \
+            --title "chore: sync upstream acestep.cpp ($(date +%Y-%m-%d))" \
+            --body "$(cat <<EOF
+          ## Upstream sync
+
+          Merging **${{ steps.check.outputs.count }}** new commit(s) from [\`ServeurpersoCom/acestep.cpp\`](https://github.com/ServeurpersoCom/acestep.cpp).
+          ${CONFLICT_NOTE}
+
+          ### New upstream commits
+          \`\`\`
+          ${{ steps.check.outputs.summary }}
+          \`\`\`
+
+          ### Review checklist
+          - [ ] CI passes after merge
+          - [ ] No regressions in our additions (workflows, plugins, web UI)
+          - [ ] Changelog updated if needed
+          EOF
+          )" \
+            --base master \
+            --head "${{ steps.merge.outputs.branch }}" \
+            --label "maintenance"


### PR DESCRIPTION
## Summary
- **Release workflow**: builds JUCE VST3 plugin on all 3 platforms (Linux, macOS, Windows) and includes `.vst3` bundles in release archives alongside CLI binaries
- **Upstream sync**: new weekly GitHub Action checks `ServeurpersoCom/acestep.cpp` for changes and auto-creates a PR for human review (addresses #8)

## Test plan
- [ ] Trigger release workflow via `workflow_dispatch` on a test tag — verify VST3 bundles appear in release assets
- [ ] Trigger upstream-sync workflow manually — verify it creates a PR (or reports "up to date")
- [ ] Verify Linux build installs JUCE dependencies (ALSA, X11, GL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)